### PR TITLE
feat: Renovate post upgrade tasks after upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,15 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>cds-snc/renovate-config"
-  ]
+  ],
+  "postUpgradeTasks": {
+    "commands": [
+      "npm install",
+      "npm run build"
+    ],
+    "fileFilters": [
+      "package.json", 
+      "package-lock.json"
+    ]
+  }
 }


### PR DESCRIPTION
# Summary
Update the Renovate config so that a new `/dist` is built and committed after dependency upgrades are finished.