### PR TITLE
fix: remove fileFilters from post upgrade tasks

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,10 +7,6 @@
     "commands": [
       "npm install",
       "npm run build"
-    ],
-    "fileFilters": [
-      "package.json", 
-      "package-lock.json"
     ]
   }
 }


### PR DESCRIPTION
# Summary
Update the post upgrade tasks to remove the file filters.  This should be left to its default value of `**/*` which causes any non-ignored file to be committed.